### PR TITLE
allow a `--server` option

### DIFF
--- a/editor/workspace.go
+++ b/editor/workspace.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/akiyosi/gonvim/fuzzy"
 	shortpath "github.com/akiyosi/short_path"
+	"github.com/jessevdk/go-flags"
 	"github.com/neovim/go-client/nvim"
 	"github.com/therecipe/qt/core"
 	"github.com/therecipe/qt/gui"
@@ -238,7 +239,17 @@ func (w *Workspace) show() {
 }
 
 func (w *Workspace) startNvim(path string) error {
-	neovim, err := nvim.NewChildProcess(nvim.ChildProcessArgs(append([]string{"--cmd", "let g:gonvim_running=1", "--embed"}, os.Args[1:]...)...))
+	var opts struct {
+		ServerPtr string `long:"server" description:"Remote session address"`
+	}
+	args, _ := flags.ParseArgs(&opts, os.Args[1:])
+	var neovim *nvim.Nvim
+	var err error
+	if opts.ServerPtr != "" {
+		neovim, err = nvim.Dial(opts.ServerPtr)
+	} else {
+		neovim, err = nvim.NewChildProcess(nvim.ChildProcessArgs(append([]string{"--cmd", "let g:gonvim_running=1", "--embed"}, args...)...))
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Just a demonstration of #27 .
I've tested it and it could be used to connect to a remote session. By using the following command:

```bash
gonvim --server ADDRESS
```

However, the latency is significantly higher than neovim-qt's remote connection for unknown reasons, so it's not really pleasant to work in this configuration.

UPDATE: Previously I said the latency is high because when you move around a file using jk, it seems to be quite slow. However, I found that if I open a `:terminal`, the latency of `jk` is quite okay in the `:terminal` window. So I guess it's caused by some specific feature that is only enabled in normal file window.