### PR TITLE
No need to send close command on windowClose event

### DIFF
--- a/editor/screen.go
+++ b/editor/screen.go
@@ -1300,7 +1300,6 @@ func (s *Screen) windowClose(args []interface{}) {
 		}
 		win := s.windows[gridid]
 		s.ws.nvim.SetCurrentWindow(win.id)
-		s.ws.nvim.Command("close")
 	}
 }
 


### PR DESCRIPTION
The event itself is from neovim, we do not need to send it back to nvim